### PR TITLE
Emit reload event when tasks finish

### DIFF
--- a/app.go
+++ b/app.go
@@ -346,9 +346,17 @@ func (a *App) DeleteTask(taskID string) error {
 	a.logger.Info("Task deleted successfully", "taskId", taskID)
 
 	// Emit event to frontend to reload videos
-	runtime.EventsEmit(a.ctx, "reload-videos")
+	a.emitReloadEvent()
 
 	return nil
+}
+
+func (a *App) emitReloadEvent() {
+	if a.ctx == nil {
+		a.logger.Warn("Cannot emit reload event before startup context is set")
+		return
+	}
+	runtime.EventsEmit(a.ctx, "reload-videos")
 }
 
 // processTask handles the actual task processing
@@ -488,6 +496,7 @@ func (a *App) processTask(task *types.Task) {
 
 	// Mark as done
 	a.taskManager.UpdateTaskStatus(types.TaskStatusDone, 100)
+	a.emitReloadEvent()
 	a.logger.Info("Task completed successfully", "taskId", task.ID)
 
 	// Clear current task ID

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -13,7 +13,7 @@ import { cn } from '@/lib/utils'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { GetAllTasks } from '../../wailsjs/go/main/App'
-import { EventsOn, EventsOff } from '../../wailsjs/runtime/runtime'
+import { EventsOn } from '../../wailsjs/runtime/runtime'
 import { types } from '../../wailsjs/go/models'
 
 export default function Layout() {
@@ -29,13 +29,13 @@ export default function Layout() {
 
   useEffect(() => {
     loadChannels()
-    
-    const cleanup = EventsOn('reload-videos', () => {
+
+    const offReload = EventsOn('reload-videos', () => {
       loadChannels()
     })
-    
+
     return () => {
-      EventsOff('reload-videos')
+      offReload()
     }
   }, [])
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -24,7 +24,7 @@ import {
   Trash2
 } from 'lucide-react'
 import { GetAllTasks, DeleteTask } from '../../wailsjs/go/main/App'
-import { EventsOn, EventsOff } from '../../wailsjs/runtime/runtime'
+import { EventsOn } from '../../wailsjs/runtime/runtime'
 
 export default function HomePage() {
   const navigate = useNavigate()
@@ -41,14 +41,14 @@ export default function HomePage() {
     loadTasks()
     
     // Listen for reload-videos event from backend
-    const cleanup = EventsOn('reload-videos', () => {
+    const offReload = EventsOn('reload-videos', () => {
       console.log('Received reload-videos event from backend')
       loadTasks()
     })
-    
+
     // Cleanup on unmount
     return () => {
-      EventsOff('reload-videos')
+      offReload()
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- wrap reload event emission in a helper that checks the startup context
- fire the reload event after task completion so new channel counts propagate

## Testing
- npm run build
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c9a96cce0c832f882ded583c4085ef