### PR TITLE
feat: add cmd+w keyboard shortcut to close window

### DIFF
--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -130,17 +130,17 @@ export namespace types {
 		    return a;
 		}
 	}
-        export class VideoMetadata {
-            id: string;
-            title: string;
-            channel: string;
-            channelId: string;
-            duration: number;
-            publishedAt: string;
-            thumbnail: string;
-            viewCount: number;
-            likeCount: number;
-            description: string;
+	export class VideoMetadata {
+	    id: string;
+	    title: string;
+	    channel: string;
+	    channelId: string;
+	    duration: number;
+	    publishedAt: string;
+	    thumbnail: string;
+	    viewCount: number;
+	    likeCount: number;
+	    description: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new VideoMetadata(source);
@@ -151,32 +151,14 @@ export namespace types {
 	        this.id = source["id"];
 	        this.title = source["title"];
 	        this.channel = source["channel"];
-                this.channelId = source["channelId"];
-                this.duration = source["duration"];
-                this.publishedAt = source["publishedAt"];
-                this.thumbnail = source["thumbnail"];
-                this.viewCount = source["viewCount"];
-                this.likeCount = source["likeCount"];
-                this.description = source["description"];
-            }
-
-                convertValues(a: any, classs: any, asMap: boolean = false): any {
-		    if (!a) {
-		        return a;
-		    }
-		    if (a.slice && a.map) {
-		        return (a as any[]).map(elem => this.convertValues(elem, classs));
-		    } else if ("object" === typeof a) {
-		        if (asMap) {
-		            for (const key of Object.keys(a)) {
-		                a[key] = new classs(a[key]);
-		            }
-		            return a;
-		        }
-		        return new classs(a);
-		    }
-		    return a;
-		}
+	        this.channelId = source["channelId"];
+	        this.duration = source["duration"];
+	        this.publishedAt = source["publishedAt"];
+	        this.thumbnail = source["thumbnail"];
+	        this.viewCount = source["viewCount"];
+	        this.likeCount = source["likeCount"];
+	        this.description = source["description"];
+	    }
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -49,7 +49,9 @@ func main() {
 	fileMenu := appMenu.AddSubmenu("File")
 	fileMenu.AddText("Close Window", keys.CmdOrCtrl("w"), func(cd *menu.CallbackData) {
 		// Quit the application when cmd+w (or ctrl+w on Windows/Linux) is pressed
-		runtime.Quit(cd.Context)
+		if app.ctx != nil {
+			runtime.Quit(app.ctx)
+		}
 	})
 
 	// Create application with options

--- a/main.go
+++ b/main.go
@@ -6,9 +6,12 @@ import (
 	"strings"
 
 	"github.com/wailsapp/wails/v2"
+	"github.com/wailsapp/wails/v2/pkg/menu"
+	"github.com/wailsapp/wails/v2/pkg/menu/keys"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 	macopts "github.com/wailsapp/wails/v2/pkg/options/mac"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 //go:embed all:frontend/dist
@@ -39,6 +42,16 @@ func main() {
 		mediaServer: app.mediaServer,
 	}
 
+	// Create application menu
+	appMenu := menu.NewMenu()
+
+	// Create File menu with Close window option
+	fileMenu := appMenu.AddSubmenu("File")
+	fileMenu.AddText("Close Window", keys.CmdOrCtrl("w"), func(cd *menu.CallbackData) {
+		// Quit the application when cmd+w (or ctrl+w on Windows/Linux) is pressed
+		runtime.Quit(cd.Context)
+	})
+
 	// Create application with options
 	err := wails.Run(&options.App{
 		Title:  "transcube-webapp",
@@ -50,6 +63,7 @@ func main() {
 		},
 		BackgroundColour: &options.RGBA{R: 255, G: 255, B: 255, A: 1},
 		OnStartup:        app.startup,
+		Menu:             appMenu,
 		Mac: &macopts.Options{
 			TitleBar: &macopts.TitleBar{
 				TitlebarAppearsTransparent: false,


### PR DESCRIPTION
Implements a File menu with Close Window option that responds to cmd+w
on macOS and ctrl+w on Windows/Linux. Uses Wails menu system to handle
the keyboard shortcut and calls runtime.Quit to close the application.

Fixes #8

Generated with [Claude Code](https://claude.ai/code)