### PR TITLE
Lower macOS minimum version requirement from 26 to 14

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -8,7 +8,7 @@
 - 隐私敏感用户：仅本地处理（除下载外），可控与可复现。
 
 ## 范围与约束（MVP）
-- 平台：macOS 26（Apple Silicon）。
+- 平台：macOS 14 Sonoma 或更高版本（Apple Silicon）。
 - 依赖：Homebrew 安装的 `yt-dlp`、`ffmpeg`、`yap`；仅检测缺失并提示，不代安装。
 - 识别：仅用 `yap` CLI（不写任何 native 代码，不用 macOS Speech）。
 - 字幕：仅 SRT；官方字幕优先且只接受英文（含 `en-auto`），其余语言一律忽略；保留官方 `captions.vtt` 与转出的 `subs_en.srt`。

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Before running TransCube, make sure you have these tools installed:
 
 #### Using Homebrew (macOS)
 
-Note: Requires macOS 26 or later.
+Note: Requires macOS 14 (Sonoma) or later.
 
 ```bash
 brew install --cask strrl/collective/transcube

--- a/build/darwin/Info.dev.plist
+++ b/build/darwin/Info.dev.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
         <string>iconfile</string>
         <key>LSMinimumSystemVersion</key>
-        <string>26.0</string>
+        <string>14.0</string>
         <key>NSHighResolutionCapable</key>
         <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/build/darwin/Info.plist
+++ b/build/darwin/Info.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
         <string>iconfile</string>
         <key>LSMinimumSystemVersion</key>
-        <string>26.0</string>
+        <string>14.0</string>
         <key>NSHighResolutionCapable</key>
         <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -118,7 +118,7 @@ VERSION_MODIFIED=true
 echo "Building version $VERSION..."
 # Enforce minimum macOS version at link time when building on macOS
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    export MACOSX_DEPLOYMENT_TARGET="26.0"
+    export MACOSX_DEPLOYMENT_TARGET="14.0"
 fi
 wails build -clean
 

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -49,7 +49,7 @@ fi
 # Build app
 echo -e "${GREEN}📦 Building app...${NC}"
 # Enforce minimum macOS version at link time
-export MACOSX_DEPLOYMENT_TARGET="26.0"
+export MACOSX_DEPLOYMENT_TARGET="14.0"
 wails build -platform darwin/universal -clean
 
 APP_PATH="build/bin/transcube-webapp.app"


### PR DESCRIPTION
## Summary
The application only requires macOS 14 (Sonoma) to support the FullscreenEnabled WebView feature. The previous macOS 26 requirement was unnecessarily restrictive and prevented users on modern systems from using the application.

## Changes
- Updated LSMinimumSystemVersion in Info.plist and Info.dev.plist to 14.0
- Updated MACOSX_DEPLOYMENT_TARGET in build.sh and sign-and-notarize.sh to 14.0
- Updated documentation in README.md and PRD.md to reflect the new requirement

## Resolves
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)